### PR TITLE
Add LAYER-1/state-transitions.md state machine policy

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -9,6 +9,10 @@
 
 ## Что мы делали в последний раз
 
+**state-transitions.md** (2026-04-18):
+
+- Добавлен [`LAYER-1/state-transitions.md`](./LAYER-1/state-transitions.md) — политика переходов состояний (Project / Session / Task), запрещённые переходы и чеклист агента; связка с обновлением [`LAYER-3/STATE.md`](./LAYER-3/STATE.md).
+
 **Оптимизация документов — ШАГ 1д** (2026-04-17):
 
 - Содержимое `LAYER-1/ux-checklist-accessibility.md`, `ux-checklist-medical.md`, `ux-checklist-interactions.md` перенесено в [`LAYER-1/ux-checklist-core.md`](./LAYER-1/ux-checklist-core.md); три отдельных файла удалены; [`stages/02-ux/ux-checklist-core.md`](./stages/02-ux/ux-checklist-core.md) — указатель на канон; ссылки и `install.sh` обновлены.

--- a/LAYER-1/state-transitions.md
+++ b/LAYER-1/state-transitions.md
@@ -1,0 +1,73 @@
+# State Transitions — Политика переходов состояний
+
+Агент обязан обновлять LAYER-3/STATE.md при каждом переходе.
+Переход = событие + guard + side effect. Без guard'а переход не выполняется.
+
+---
+
+## Project State Transitions
+
+| From | Event | Guard | To | Side Effects |
+|---|---|---|---|---|
+| INIT | INTERVIEW_STARTED | interview-session.md создан | DISCOVERY | Обновить STATE.md |
+| DISCOVERY | INTERVIEW_CONFIRMED | все поля interview-session.md заполнены | PLANNING | Обновить project-status.md |
+| PLANNING | PLAN_APPROVED | явное подтверждение пользователя | DEVELOPMENT | Записать в atomic-decisions.md |
+| DEVELOPMENT | TASK_IMPLEMENTED | self-verification пройдена | REVIEW | Запустить audit.md |
+| REVIEW | AUDIT_PASSED | нет блокеров в audit.md | RELEASE_READY | Обновить HANDOFF.md |
+| RELEASE_READY | DEPLOY_CONFIRMED | явное подтверждение пользователя | MAINTENANCE | Обновить project-status.md |
+| MAINTENANCE | NEW_TASK_ACCEPTED | task добавлен в roadmap | DEVELOPMENT | Обновить Task State |
+| любая | ERROR_DETECTED | ошибка классифицирована | ERROR | Запустить error-handling.md, открыть инцидент |
+| ERROR | ROLLBACK_COMPLETED | причина устранена, откат зафиксирован | предыдущая | Записать в incidents/ |
+
+---
+
+## Session State Transitions
+
+| From | Event | Guard | To | Side Effects |
+|---|---|---|---|---|
+| BOOTSTRAP | CONTEXT_RESTORED | STATE.md + project-status.md прочитаны | CONTEXT_LOADED | Сформировать next allowed actions |
+| CONTEXT_LOADED | PLAN_PRESENTED | план существует | AWAITING_CONFIRMATION | Записать snapshot плана |
+| AWAITING_CONFIRMATION | USER_APPROVED | явное "да" от пользователя | EXECUTING | Зафиксировать active task |
+| EXECUTING | EXECUTION_FINISHED | реализация завершена | VERIFYING | Запустить self-verification.md |
+| VERIFYING | VERIFICATION_PASSED | нет блокеров | HANDOFF | Обновить HANDOFF.md + project-status.md |
+| EXECUTING | ERROR_DETECTED | ошибка классифицирована | INTERRUPTED | Открыть инцидент |
+| INTERRUPTED | ROLLBACK_COMPLETED | откат выполнен | CONTEXT_LOADED | Записать в incidents/ |
+
+---
+
+## Task State Transitions
+
+| From | Event | Guard | To | Side Effects |
+|---|---|---|---|---|
+| DRAFT | TASK_PLANNED | задача описана в roadmap | PLANNED | Обновить Task State в STATE.md |
+| PLANNED | USER_APPROVED | явное подтверждение | IN_PROGRESS | Зафиксировать в session-log.md |
+| IN_PROGRESS | TASK_IMPLEMENTED | код/артефакт создан | REVIEW | Запустить self-verification |
+| REVIEW | REVIEW_PASSED | нет замечаний | DONE | Обновить project-status.md |
+| IN_PROGRESS | BLOCKER_FOUND | блокер зафиксирован | BLOCKED | Записать в STATE.md → blockers |
+| BLOCKED | BLOCKER_RESOLVED | блокер устранён | IN_PROGRESS | Убрать из blockers |
+| любая | ROLLBACK_TRIGGERED | откат подтверждён | ROLLED_BACK | Запустить error-handling.md |
+
+---
+
+## Запрещённые переходы (Illegal Transitions)
+
+Агент НИКОГДА не выполняет эти переходы, даже если пользователь просит:
+
+- `PLANNED → DONE` — задача не может быть завершена без выполнения
+- `BOOTSTRAP → EXECUTING` — нельзя начать работу без загрузки контекста
+- `BLOCKED → DONE` — нельзя закрыть заблокированную задачу
+- `REVIEW → DEVELOPMENT` — нельзя вернуться без фиксации причины в session-log.md
+- `RELEASE_READY → MAINTENANCE` — нельзя без DEPLOY_CONFIRMED от пользователя
+- `ERROR → HANDOFF` — нельзя завершать сессию с активным инцидентом
+- `любая → EXECUTING` — без явного USER_APPROVED
+
+---
+
+## Правила агента при каждом переходе
+
+1. Проверить guard — если не выполнен, переход заблокирован
+2. Обновить поле `state` в нужном домене STATE.md
+3. Обновить поле `last_event` и `last_updated`
+4. Дописать запись в `Transition Log` в STATE.md
+5. Выполнить все Side Effects из таблицы
+6. Сообщить пользователю: "Переход: X → Y (событие: EVENT)"

--- a/LAYER-3/project-status.md
+++ b/LAYER-3/project-status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-> Updated: 2026-04-17 (ШАГ 1д UX-чеклисты)
+> Updated: 2026-04-18 (state-transitions.md)
 
 ## Текущий этап
 
@@ -27,6 +27,8 @@
 Пояснение: знаки `❓` в исходном шаблоне ожидаемы до начала реального проекта.
 
 ## Последнее действие
+
+2026-04-18 — **state-transitions:** добавлен [`state-transitions.md`](../LAYER-1/state-transitions.md) — таблицы переходов и illegal transitions; агент обновляет [`STATE.md`](./STATE.md) при каждом переходе. См. [`HANDOFF.md`](../HANDOFF.md).
 
 2026-04-17 — **Оптимизация ШАГ 1д + скан ссылок:** все UX-чеклисты в [`ux-checklist-core.md`](../LAYER-1/ux-checklist-core.md); удалены отдельные UX-файлы; скан относительных ссылок в `*.md` / `*.mdc` / `*.txt` — 0 битых. См. [`HANDOFF.md`](../HANDOFF.md).
 

--- a/memory-bank/project-status.md
+++ b/memory-bank/project-status.md
@@ -5,4 +5,4 @@
 
 ## Статус
 
-Смотри [`LAYER-3/project-status.md`](../LAYER-3/project-status.md) (обновлено 2026-04-17: ШАГ 1д + скан ссылок; 1г/1в/1б/1а; см. [`HANDOFF.md`](../HANDOFF.md)).
+Смотри [`LAYER-3/project-status.md`](../LAYER-3/project-status.md) (обновлено 2026-04-18: `state-transitions.md`; ранее 2026-04-17 ШАГ 1д и др.; см. [`HANDOFF.md`](../HANDOFF.md)).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change adds `LAYER-1/state-transitions.md` with the canonical transition tables for project, session, and task states, illegal transitions, and the agent checklist for each transition (including updates to `LAYER-3/STATE.md`).

`HANDOFF.md`, `LAYER-3/project-status.md`, and `memory-bank/project-status.md` are updated to record the addition.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2431ab61-8375-41a1-aaab-e1492813e7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2431ab61-8375-41a1-aaab-e1492813e7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

