### PR TITLE
Prepend session bootstrap and handoff protocols to agent-rules.md

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -9,6 +9,10 @@
 
 ## Что мы делали в последний раз
 
+**agent-rules.md — BOOTSTRAP PROTOCOL** (2026-04-18):
+
+- В начало [`LAYER-1/agent-rules.md`](./LAYER-1/agent-rules.md) добавлены блоки BOOTSTRAP PROTOCOL, STATE AUTHORITY и HANDOFF PROTOCOL (строгий порядок чтения STATE / project-status / session-log / atomic-decisions, handoff-шаги).
+
 **Оптимизация документов — ШАГ 1д** (2026-04-17):
 
 - Содержимое `LAYER-1/ux-checklist-accessibility.md`, `ux-checklist-medical.md`, `ux-checklist-interactions.md` перенесено в [`LAYER-1/ux-checklist-core.md`](./LAYER-1/ux-checklist-core.md); три отдельных файла удалены; [`stages/02-ux/ux-checklist-core.md`](./stages/02-ux/ux-checklist-core.md) — указатель на канон; ссылки и `install.sh` обновлены.

--- a/LAYER-1/agent-rules.md
+++ b/LAYER-1/agent-rules.md
@@ -1,3 +1,50 @@
+# BOOTSTRAP PROTOCOL — Обязательный старт каждой сессии
+<!-- Выполняется строго до любых других действий. Нарушение протокола недопустимо. -->
+
+## Шаги bootstrap (порядок строгий):
+
+1. Прочитать LAYER-3/STATE.md
+   → определить Project State, Session State, Task State
+   → проверить Guards и blockers
+2. Прочитать LAYER-3/project-status.md
+   → уточнить детали прогресса
+3. Прочитать LAYER-3/session-log.md
+   → что происходило в прошлую сессию
+4. Прочитать LAYER-3/atomic-decisions.md
+   → какие решения закрыты и не обсуждаются повторно
+5. Прочитать активную задачу (если есть active_task в STATE.md)
+6. Сформировать и сообщить пользователю:
+   - текущий Project State
+   - текущий Task State
+   - Next Allowed Actions из STATE.md
+   - список блокеров (если есть)
+7. Перевести Session State: BOOTSTRAP → CONTEXT_LOADED
+8. [BOOTSTRAP COMPLETE] — только теперь начинать работу
+
+## STATE AUTHORITY — Кто меняет состояние:
+
+| Переход | Инициатор | Требуется подтверждение пользователя |
+|---|---|---|
+| INIT → DISCOVERY | агент | нет |
+| DISCOVERY → PLANNING | агент | нет |
+| PLANNING → DEVELOPMENT | агент | ДА — явное "да" |
+| DEVELOPMENT → REVIEW | агент | нет |
+| REVIEW → RELEASE_READY | агент после audit | нет |
+| RELEASE_READY → MAINTENANCE | агент | ДА — явное "да" |
+| любая → ERROR | агент | нет |
+| AWAITING_CONFIRMATION → EXECUTING | агент | ДА — явное "да" |
+
+## HANDOFF PROTOCOL — Завершение каждой сессии:
+
+1. Обновить STATE.md (все три домена)
+2. Дописать в session-log.md: `[дата] [фаза] [что сделано] [следующий шаг]`
+3. Обновить project-status.md
+4. Перевести Session State → HANDOFF
+5. Обновить HANDOFF.md в формате terminal snapshot
+
+---
+<!-- конец протокола, ниже существующее содержимое agent-rules.md -->
+
 > Trigger: Старт сессии, конфликт инструкций, модульный пайплайн
 > Read-time: ~20 min
 > Filled-by: agent / both

--- a/LAYER-3/project-status.md
+++ b/LAYER-3/project-status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-> Updated: 2026-04-17 (ШАГ 1д UX-чеклисты)
+> Updated: 2026-04-18 (agent-rules bootstrap protocol)
 
 ## Текущий этап
 
@@ -27,6 +27,8 @@
 Пояснение: знаки `❓` в исходном шаблоне ожидаемы до начала реального проекта.
 
 ## Последнее действие
+
+2026-04-18 — **agent-rules:** в начало [`agent-rules.md`](../LAYER-1/agent-rules.md) добавлен BOOTSTRAP / STATE AUTHORITY / HANDOFF протоколы. См. [`HANDOFF.md`](../HANDOFF.md).
 
 2026-04-17 — **Оптимизация ШАГ 1д + скан ссылок:** все UX-чеклисты в [`ux-checklist-core.md`](../LAYER-1/ux-checklist-core.md); удалены отдельные UX-файлы; скан относительных ссылок в `*.md` / `*.mdc` / `*.txt` — 0 битых. См. [`HANDOFF.md`](../HANDOFF.md).
 

--- a/memory-bank/project-status.md
+++ b/memory-bank/project-status.md
@@ -5,4 +5,4 @@
 
 ## Статус
 
-Смотри [`LAYER-3/project-status.md`](../LAYER-3/project-status.md) (обновлено 2026-04-17: ШАГ 1д + скан ссылок; 1г/1в/1б/1а; см. [`HANDOFF.md`](../HANDOFF.md)).
+Смотри [`LAYER-3/project-status.md`](../LAYER-3/project-status.md) (обновлено 2026-04-18: bootstrap в `agent-rules.md`; ранее 2026-04-17 ШАГ 1д и др.; см. [`HANDOFF.md`](../HANDOFF.md)).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change prepends the BOOTSTRAP PROTOCOL, STATE AUTHORITY, and HANDOFF PROTOCOL blocks to the start of `LAYER-1/agent-rules.md`, before the existing frontmatter and AGENT-RULES content, without removing any prior text.

`HANDOFF.md`, `LAYER-3/project-status.md`, and `memory-bank/project-status.md` record the update.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2431ab61-8375-41a1-aaab-e1492813e7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2431ab61-8375-41a1-aaab-e1492813e7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

