### PR TITLE
Add TERMINAL SESSION SNAPSHOT to top of HANDOFF.md

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,3 +1,30 @@
+# TERMINAL SESSION SNAPSHOT
+<!-- Заполняется агентом при завершении каждой сессии -->
+<!-- Следующий агент начинает чтение именно отсюда -->
+
+## State при завершении сессии
+Project State: ""
+Session State: HANDOFF
+Task State: ""
+Active Task: ""
+Last Transition: "" → ""
+Last Event: ""
+
+## Next Allowed Actions
+- ""
+
+## Blockers (если есть)
+- ""
+
+## Что сделано в этой сессии (1–3 строки)
+- ""
+
+## Что должен сделать следующий агент первым шагом
+- ""
+
+---
+<!-- ниже существующее содержимое HANDOFF.md -->
+
 # HANDOFF — где мы остановились
 
 ## Project Name
@@ -8,6 +35,10 @@
 > Агент обновляет этот файл после каждой сессии.
 
 ## Что мы делали в последний раз
+
+**HANDOFF.md — TERMINAL SESSION SNAPSHOT** (2026-04-18):
+
+- В начало [`HANDOFF.md`](./HANDOFF.md) добавлен блок **TERMINAL SESSION SNAPSHOT** (state при завершении, next actions, blockers, краткий отчёт и первый шаг для следующего агента).
 
 **Оптимизация документов — ШАГ 1д** (2026-04-17):
 
@@ -142,4 +173,4 @@
 
 ## Применимые уроки
 
-- Перед началом сессии: `LAYER-3/project-status.md`, `LAYER-3/lessons.md`, `LAYER-3/session-log.md`.
+- Перед началом сессии: верх файла `HANDOFF.md` (**TERMINAL SESSION SNAPSHOT**), `LAYER-3/project-status.md`, `LAYER-3/lessons.md`, `LAYER-3/session-log.md`.

--- a/LAYER-3/project-status.md
+++ b/LAYER-3/project-status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-> Updated: 2026-04-17 (ШАГ 1д UX-чеклисты)
+> Updated: 2026-04-18 (HANDOFF terminal snapshot)
 
 ## Текущий этап
 
@@ -27,6 +27,8 @@
 Пояснение: знаки `❓` в исходном шаблоне ожидаемы до начала реального проекта.
 
 ## Последнее действие
+
+2026-04-18 — **HANDOFF:** в начало [`HANDOFF.md`](../HANDOFF.md) добавлен блок **TERMINAL SESSION SNAPSHOT** для handoff между сессиями. См. [`HANDOFF.md`](../HANDOFF.md).
 
 2026-04-17 — **Оптимизация ШАГ 1д + скан ссылок:** все UX-чеклисты в [`ux-checklist-core.md`](../LAYER-1/ux-checklist-core.md); удалены отдельные UX-файлы; скан относительных ссылок в `*.md` / `*.mdc` / `*.txt` — 0 битых. См. [`HANDOFF.md`](../HANDOFF.md).
 

--- a/memory-bank/project-status.md
+++ b/memory-bank/project-status.md
@@ -5,4 +5,4 @@
 
 ## Статус
 
-Смотри [`LAYER-3/project-status.md`](../LAYER-3/project-status.md) (обновлено 2026-04-17: ШАГ 1д + скан ссылок; 1г/1в/1б/1а; см. [`HANDOFF.md`](../HANDOFF.md)).
+Смотри [`LAYER-3/project-status.md`](../LAYER-3/project-status.md) (обновлено 2026-04-18: terminal snapshot в `HANDOFF.md`; ранее 2026-04-17 ШАГ 1д и др.; см. [`HANDOFF.md`](../HANDOFF.md)).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change prepends the **TERMINAL SESSION SNAPSHOT** block to the start of `HANDOFF.md` (session state at close, next actions, blockers, session summary, and first step for the next agent), before the existing HANDOFF content.

`LAYER-3/project-status.md` and `memory-bank/project-status.md` are updated to record the change; `HANDOFF.md` “Применимые уроки” now points readers to the snapshot at the top of the file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2431ab61-8375-41a1-aaab-e1492813e7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2431ab61-8375-41a1-aaab-e1492813e7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

