### PR TITLE
chore: unify adapter entrypoints around canonical bootstrap

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,5 @@
+# Aider Entry Point — adapter only, not a policy source
+# Canonical bootstrap: LAYER-1/agent-rules.md
+# Then follow that protocol exactly
+read:
+  - LAYER-1/agent-rules.md

--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -1,26 +1,17 @@
 ---
-description: Docs-first core — read order, routing, and post-change updates for Vibe-coding-docs
+description: Adapter entry point for Cursor — routes to canonical bootstrap
 alwaysApply: true
 ---
 
-# 00-core.mdc — Agent Entry Point
+<!-- ROLE: ADAPTER -->
+<!-- AUTHORITY: NON-AUTHORITY -->
+<!-- STATUS: ACTIVE -->
+<!-- UPDATED_BY: owner -->
+<!-- SOURCE_OF_TRUTH: no -->
+<!-- MUST_NOT_CONTAIN: policy, bootstrap order, runtime state -->
 
-## Bootstrap (strict order)
-1. Read LAYER-3/STATE.md
-2. Read LAYER-3/project-status.md
-3. Read LAYER-1/agent-rules.md
-4. Follow LAYER-1/state-transitions.md
+# Cursor Rules — Entry Point
 
-## Canonical sources
-- Logic:         LAYER-1/
-- State:         LAYER-3/STATE.md
-- Architecture:  ARCHITECTURE.md
-- Handoff:       HANDOFF.md
-- Navigation:    llms.txt
-
-## Rule
-Project logic → LAYER-1/
-IDE-specific config → this file only
-
-> This file contains only pointers. No project logic here.
----
+This file is an adapter, not a policy source.
+Read `LAYER-1/agent-rules.md` — canonical bootstrap protocol.
+Then follow that protocol exactly.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -5,7 +5,7 @@
 <!-- SOURCE_OF_TRUTH: no -->
 <!-- MUST_NOT_CONTAIN: policy, bootstrap order, runtime state -->
 
-# AGENTS.md — Universal Agent Entry Point
+# .windsurfrules — Windsurf Entry Point
 
 This file is an adapter, not a policy source.
 Read `LAYER-1/agent-rules.md` — canonical bootstrap protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,12 @@
----
-# CLAUDE.md — Agent Entry Point
+<!-- ROLE: ADAPTER -->
+<!-- AUTHORITY: NON-AUTHORITY -->
+<!-- STATUS: ACTIVE -->
+<!-- UPDATED_BY: owner -->
+<!-- SOURCE_OF_TRUTH: no -->
+<!-- MUST_NOT_CONTAIN: policy, bootstrap order, runtime state -->
 
-## Bootstrap (strict order)
-1. Read LAYER-3/STATE.md
-2. Read LAYER-3/project-status.md
-3. Read LAYER-1/agent-rules.md
-4. Follow LAYER-1/state-transitions.md
+# CLAUDE.md — Claude Code Entry Point
 
-## Canonical sources
-- Logic:         LAYER-1/
-- State:         LAYER-3/STATE.md
-- Architecture:  ARCHITECTURE.md
-- Handoff:       HANDOFF.md
-- Navigation:    llms.txt
-
-## Rule
-Project logic → LAYER-1/
-IDE-specific config → this file only
-
-> This file contains only pointers. No project logic here.
----
+This file is an adapter, not a policy source.
+Read `LAYER-1/agent-rules.md` — canonical bootstrap protocol.
+Then follow that protocol exactly.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,22 +1,12 @@
----
-# GEMINI.md — Agent Entry Point
+<!-- ROLE: ADAPTER -->
+<!-- AUTHORITY: NON-AUTHORITY -->
+<!-- STATUS: ACTIVE -->
+<!-- UPDATED_BY: owner -->
+<!-- SOURCE_OF_TRUTH: no -->
+<!-- MUST_NOT_CONTAIN: policy, bootstrap order, runtime state -->
 
-## Bootstrap (strict order)
-1. Read LAYER-3/STATE.md
-2. Read LAYER-3/project-status.md
-3. Read LAYER-1/agent-rules.md
-4. Follow LAYER-1/state-transitions.md
+# GEMINI.md — Gemini CLI Entry Point
 
-## Canonical sources
-- Logic:         LAYER-1/
-- State:         LAYER-3/STATE.md
-- Architecture:  ARCHITECTURE.md
-- Handoff:       HANDOFF.md
-- Navigation:    llms.txt
-
-## Rule
-Project logic → LAYER-1/
-IDE-specific config → this file only
-
-> This file contains only pointers. No project logic here.
----
+This file is an adapter, not a policy source.
+Read `LAYER-1/agent-rules.md` — canonical bootstrap protocol.
+Then follow that protocol exactly.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -27,6 +27,7 @@ Last event (reference, не canonical): ITERATION_3_COMPLETED
 Last transition (reference, не canonical): DEVELOPMENT → MAINTENANCE (2026-04-19)
 
 Что сделано в последней сессии:
+- Adapter entrypoints сведены к минимальному указателю на `LAYER-1/agent-rules.md`: `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursor/rules/00-core.mdc`; добавлены `.windsurfrules`, `.aider.conf.yml`; в `LAYER-1/document-governance.md` — строки registry для GEMINI, Windsurf, Aider; `opencode.json` не менялся (в текущей схеме нет безопасного поля для текста инструкций); `llms.txt` проверен — без конфликта с каноническим bootstrap в `agent-rules.md`.
 - Миграция фаз 2–4: разведены STATE / HANDOFF / project-status; session-log append; state-aware + document governance audit в `audit.md`; `document-governance.md`; единый bootstrap в `agent-rules.md`.
 - В `dev` влита ветка `cursor/handoff-three-zone-restructure-e7fa`: разрешены конфликты в
   `HANDOFF.md`, `LAYER-3/STATE.md`, `LAYER-3/project-status.md`, `memory-bank/project-status.md`.

--- a/LAYER-1/document-governance.md
+++ b/LAYER-1/document-governance.md
@@ -127,6 +127,9 @@
 | CLAUDE.md | ADAPTER | NON-AUTHORITY | ACTIVE | owner | Adapter only |
 | .cursor/rules/* | ADAPTER | NON-AUTHORITY | ACTIVE | owner | Adapter only |
 | AGENTS.md | ADAPTER | NON-AUTHORITY | ACTIVE | owner | Adapter only |
+| GEMINI.md | ADAPTER | NON-AUTHORITY | ACTIVE | owner | Gemini CLI native adapter |
+| .windsurfrules | ADAPTER | NON-AUTHORITY | ACTIVE | owner | Windsurf repository convention |
+| .aider.conf.yml | ADAPTER | NON-AUTHORITY | ACTIVE | owner | Aider repository convention |
 | LAYER-3/session-log.md | REFERENCE | SECONDARY | ACTIVE | agent | Append only |
 | CHANGELOG.md | REFERENCE | NON-AUTHORITY | LIMITED | both | Historical record |
 | LAYER-1/deprecated/* | DEPRECATED | NON-AUTHORITY | DEPRECATED | manual-only | Replaced by: см. шапку каждого файла |

--- a/memory-bank/project-status.md
+++ b/memory-bank/project-status.md
@@ -7,3 +7,5 @@
 ## Статус
 
 Смотри [`LAYER-3/STATE.md`](../LAYER-3/STATE.md), затем [`HANDOFF.md`](../HANDOFF.md), затем [`LAYER-3/project-status.md`](../LAYER-3/project-status.md) (разведение ролей; см. [`HANDOFF.md`](../HANDOFF.md)).
+
+Последнее: унифицированы adapter entrypoints (pointer → `LAYER-1/agent-rules.md`), добавлены `.windsurfrules` и `.aider.conf.yml`, обновлён registry в `document-governance.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adapter entry point files now delegate entirely to `LAYER-1/agent-rules.md` as the canonical bootstrap protocol. Each Markdown adapter uses the agreed metadata block and a short pointer body (no local bootstrap order, no policy).

## Changes

- **CLAUDE.md, AGENTS.md, GEMINI.md** — minimal adapter format with specified titles.
- **`.cursor/rules/00-core.mdc`** — required YAML frontmatter preserved and updated; body replaced with adapter metadata + pointer only.
- **`.windsurfrules`** — new repository-level convention for Windsurf-style tools.
- **`.aider.conf.yml`** — new repository-level convention with `read: - LAYER-1/agent-rules.md` (YAML cannot carry HTML metadata; noted in governance).
- **`LAYER-1/document-governance.md`** — Canonical document registry only: added rows for `GEMINI.md`, `.windsurfrules`, `.aider.conf.yml` (no duplicates for existing adapters).
- **`opencode.json`** — intentionally unchanged; current schema is plugin-only and has no supported field for free-text instructions without inventing unsupported keys.
- **`llms.txt`** — reviewed: single navigation bootstrap path aligned with `agent-rules.md` (no competing adapter-specific bootstrap paths); no edit required.
- **HANDOFF.md** / **memory-bank/project-status.md** — session handoff and mirror status updated per project convention.

## Limitations

- **opencode.json**: cannot safely embed adapter text under the current schema; remains plugin configuration only.
- **`.aider.conf.yml`**: format does not support HTML comment metadata; role is documented in registry and this PR body.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0c87587-8aca-4395-8ac2-4d75fa87257c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0c87587-8aca-4395-8ac2-4d75fa87257c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

