### PR TITLE
fix: point installer to canonical AgentOS repository

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Vibe-coding-docs — установка в текущую папку проекта.
-# Источник: https://github.com/NMF13579/Vibe-coding-docs
+# AgentOS — установка в текущую папку проекта.
+# Источник: https://github.com/NMF13579/AgentOS
 
 set -euo pipefail
 
-readonly REPO_URL="https://github.com/NMF13579/Vibe-coding-docs.git"
-readonly TMP_ROOT="/tmp/vibe-docs-install"
+readonly REPO_URL="https://github.com/NMF13579/AgentOS.git"
+readonly TMP_ROOT="/tmp/agentos-install"
 
 # ANSI colors
 readonly C_GREEN='\033[0;32m'
@@ -178,7 +178,7 @@ inject_handoff_project_name() {
 
 # --- main ---
 
-printf '%b%s%b\n' "$C_GREEN" "Добро пожаловать в установщик Vibe-coding-docs." "$C_RESET"
+printf '%b%s%b\n' "$C_GREEN" "Добро пожаловать в установщик AgentOS." "$C_RESET"
 printf '%s\n' "Файлы будут скопированы в: $(pwd)"
 echo ""
 
@@ -246,9 +246,9 @@ rm -rf "$TMP_ROOT"
 
 N=${#COPIED_LIST[@]}
 echo ""
-info_green "✅ Vibe-coding-docs установлен"
+info_green "✅ AgentOS установлен"
 printf '%s\n' "📁 Скопировано файлов: ${N}"
-info_green "👉 Следующий шаг: открой CLAUDE.md и скажи агенту «Начнём»"
+info_green "👉 Следующий шаг: открой START.md (онбординг) или llms.txt (каноничный порядок для агента в этом репозитории)"
 echo ""
 printf '%b%s%b\n' "$C_GREEN" "Список скопированных файлов:" "$C_RESET"
 if [[ "$N" -eq 0 ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates `install.sh` so it clones from the canonical `NMF13579/AgentOS` repository, uses an AgentOS-named temp directory, and refreshes user-facing messages and the post-install hint to reference `START.md` and `llms.txt` instead of legacy branding.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e3bdf55-1347-44fc-9bcb-c51269fa8e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e3bdf55-1347-44fc-9bcb-c51269fa8e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

