### PR TITLE
ci: add identity drift enforcement for key files

### DIFF
--- a/.github/workflows/doc-integrity.yml
+++ b/.github/workflows/doc-integrity.yml
@@ -3,13 +3,16 @@ name: Doc Integrity
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Identity drift (legacy name in key files)
+        run: bash scripts/check-identity-drift.sh
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/scripts/check-identity-drift.sh
+++ b/scripts/check-identity-drift.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Fail if legacy product/repo identity appears in key files without an explicit historical marker on the same line.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Legacy identity: old product name (with optional extra hyphens in badges) or old GitHub paths.
+readonly DRIFT_PATTERN='[Vv]ibe-+[Cc]oding-+[Dd]ocs|github\.com/NMF13579/Vibe-coding-docs|raw\.githubusercontent\.com/NMF13579/Vibe-coding-docs'
+
+# Same line must contain one of these if DRIFT_PATTERN matches (explicit historical / disclaimer context).
+readonly HIST_PATTERN='[Hh]istorical|[Ии]сторич|[Рр]анее репозитор|not current product name|[Пп]режнее имя|[Ll]egacy name|[Oo]ld name|[Ff]ormerly'
+
+fail=0
+
+check_file() {
+  local f="$1"
+  local line_num=0
+
+  [[ -f "$f" ]] || {
+    echo "identity-check: skip missing file: $f" >&2
+    return 0
+  }
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_num=$((line_num + 1))
+    if printf '%s\n' "$line" | grep -qE "$DRIFT_PATTERN"; then
+      if ! printf '%s\n' "$line" | grep -qE "$HIST_PATTERN"; then
+        printf '%s\n' "identity-check: FAIL $f:$line_num (legacy identity without historical marker on same line)" >&2
+        printf '%s\n' "$line" >&2
+        fail=1
+      fi
+    fi
+  done <"$f"
+}
+
+check_file README.md
+check_file ARCHITECTURE.md
+check_file llms.txt
+check_file HANDOFF.md
+check_file install.sh
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "identity-check: add an explicit historical disclaimer on the same line, or remove legacy identity from key files." >&2
+  exit 1
+fi
+
+echo "identity-check: OK"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `scripts/check-identity-drift.sh` to fail CI when legacy product/repo strings appear in README, ARCHITECTURE, llms.txt, HANDOFF, or install.sh without an explicit same-line historical marker. Wires the check into the existing Doc Integrity workflow and runs that workflow on pushes to `dev` as well as `main`.

Note: until README/install identity fixes land on `dev`, merging this alone will make Doc Integrity red on `dev`; merge after or together with the AgentOS README/install PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e3bdf55-1347-44fc-9bcb-c51269fa8e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e3bdf55-1347-44fc-9bcb-c51269fa8e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

